### PR TITLE
Fix: 사용자의 답변과 꼬리 질문이 DB에 저장되지 않는 문제 수정

### DIFF
--- a/src/main/java/org/minturtle/careersupport/interview/controller/InterviewController.java
+++ b/src/main/java/org/minturtle/careersupport/interview/controller/InterviewController.java
@@ -91,7 +91,7 @@ public class InterviewController {
             @PathVariable String templateId,
             @RequestBody InterviewProcessRequest reqBody
     ){
-        Flux<String> followQuestion = interviewService.getFollowQuestion(templateId, reqBody.getAnswer());
+        Flux<String> followQuestion = interviewService.getFollowQuestion(templateId, reqBody.getAnswer()).cache();
 
         Mono<Void> saveQuestion = onCompleteSaveMessage(
                 followQuestion,
@@ -107,7 +107,9 @@ public class InterviewController {
 
         return followQuestion
                 .doOnComplete(() -> {
-                    saveAnswer.then(saveQuestion);
+                    saveAnswer
+                            .then(saveQuestion)
+                            .subscribe();
                 });
     }
 

--- a/src/test/java/org/minturtle/careersupport/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/org/minturtle/careersupport/interview/controller/InterviewControllerTest.java
@@ -307,9 +307,10 @@ class InterviewControllerTest extends IntegrationTest {
         verify(chatService, times(1))
                 .generate(anyString(), eq(theme));
 
-        Flux<InterviewMessage> messages = interviewMessageRepository.findAll();
-
-        messages.collectList().subscribe(li->assertThat(li.size()).isEqualTo(1));
+        StepVerifier.create(interviewMessageRepository.findAll())
+                .assertNext(message->{
+                    assertThat(message.getContent()).isEqualTo("질문:당신의 이름은?");
+                });
     }
 
     @Test
@@ -364,6 +365,12 @@ class InterviewControllerTest extends IntegrationTest {
                 .verifyComplete();
 
         verify(chatService, times(1)).generate(anyString(), eq(List.of(prevQuestionContent)), eq(userAnswer));
+        StepVerifier.create(interviewMessageRepository.findAll()
+                        .filter(m -> m.getSender() == InterviewMessage.SenderType.USER))
+                .assertNext(message -> {
+                    assertThat(message.getContent()).isEqualTo("제 이름은 김민석 입니다.");
+                })
+                .verifyComplete();
     }
 
 }


### PR DESCRIPTION
### 개요
- 테스트 코드가 잘못 작성되어 assert문이 실행되기 전에 테스트 케이스가 종료되는 문제가 있습니다.
- 이를 해결하기 위해 StepVerifier를 사용해 테스트 해야함을 알았습니다.
- 사용자의 답변과 꼬리 질문이 DB에 저장되도록 수정하였습니다.