### PR TITLE
Feature: Career Support용 API Access Token 발급, 저장 기능

### DIFF
--- a/src/main/java/org/minturtle/careersupport/auth/utils/ApiTokenProvider.java
+++ b/src/main/java/org/minturtle/careersupport/auth/utils/ApiTokenProvider.java
@@ -1,28 +1,48 @@
 package org.minturtle.careersupport.auth.utils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.minturtle.careersupport.common.aop.Logging;
 import org.minturtle.careersupport.common.exception.BadRequestException;
+import org.minturtle.careersupport.common.exception.InternalServerException;
 import org.minturtle.careersupport.common.utils.ReactiveEncryptUtils;
+import org.minturtle.careersupport.user.dto.UserInfoDto;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 
 @Component
 @RequiredArgsConstructor
+@Logging
 public class ApiTokenProvider {
 
     private final ReactiveEncryptUtils encryptUtils;
+    private final ObjectMapper objectMapper;
+
+    public Mono<String> generate(UserInfoDto userInfoDto){
+        try {
+            return encryptUtils.encrypt(objectMapper.writeValueAsString(userInfoDto))
+                    .map(it-> "cs_" + it);
+        }catch (JsonProcessingException e){
+            throw new InternalServerException("API 토큰 생성 중 예상치 못한 오류가 발생했습니다.", e);
+        }
 
 
-    public Mono<String> generate(String userId){
-        return encryptUtils.encrypt(userId)
-                .map(it-> "cs_" + it);
     }
 
-    public Mono<String> decryptApiToken(String token){
+    public Mono<UserInfoDto> decryptApiToken(String token) {
         if (token == null || !token.startsWith("cs_")) {
             return Mono.error(new BadRequestException("토큰이 올바르지 않습니다."));
         }
-        return encryptUtils.decrypt(token.substring(3));
+
+        return encryptUtils.decrypt(token.substring(3)).map(decrypted -> {
+            try {
+                return objectMapper.readValue(decrypted, UserInfoDto.class);
+            } catch (JsonProcessingException e) {
+                throw new InternalServerException("API 토큰 해독 중 예상치 못한 오류가 발생했습니다.");
+            }
+        });
+
     }
 }

--- a/src/main/java/org/minturtle/careersupport/auth/utils/ApiTokenProvider.java
+++ b/src/main/java/org/minturtle/careersupport/auth/utils/ApiTokenProvider.java
@@ -1,0 +1,28 @@
+package org.minturtle.careersupport.auth.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.minturtle.careersupport.common.exception.BadRequestException;
+import org.minturtle.careersupport.common.utils.ReactiveEncryptUtils;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+
+@Component
+@RequiredArgsConstructor
+public class ApiTokenProvider {
+
+    private final ReactiveEncryptUtils encryptUtils;
+
+
+    public Mono<String> generate(String userId){
+        return encryptUtils.encrypt(userId)
+                .map(it-> "cs_" + it);
+    }
+
+    public Mono<String> decryptApiToken(String token){
+        if (token == null || !token.startsWith("cs_")) {
+            return Mono.error(new BadRequestException("토큰이 올바르지 않습니다."));
+        }
+        return encryptUtils.decrypt(token.substring(3));
+    }
+}

--- a/src/main/java/org/minturtle/careersupport/common/config/SecurityConfig.java
+++ b/src/main/java/org/minturtle/careersupport/common/config/SecurityConfig.java
@@ -58,7 +58,6 @@ public class SecurityConfig {
                 .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
                 .addFilterAt(jwtAuthenticationFilter, SecurityWebFiltersOrder.AUTHENTICATION)
                 .addFilterAt(apiTokenFilter, SecurityWebFiltersOrder.AUTHENTICATION)
-                .securityMatcher(ServerWebExchangeMatchers.pathMatchers("/api/code-review"))
                 .build();
     }
 }

--- a/src/main/java/org/minturtle/careersupport/common/controller/CommonController.java
+++ b/src/main/java/org/minturtle/careersupport/common/controller/CommonController.java
@@ -1,6 +1,8 @@
 package org.minturtle.careersupport.common.controller;
 
 
+import org.minturtle.careersupport.user.dto.UserInfoDto;
+import org.minturtle.careersupport.user.resolvers.annotations.CurrentUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,5 +17,14 @@ public class CommonController {
     @ResponseStatus(HttpStatus.OK)
     public void healthCheck(){
     }
+
+    @GetMapping("/api-check")
+    @ResponseStatus(HttpStatus.OK)
+    public String apiTokenCheck(
+            @CurrentUser UserInfoDto user
+    ){
+        return "hello " + user.getNickname();
+    }
+
 
 }

--- a/src/main/java/org/minturtle/careersupport/common/exception/InternalServerException.java
+++ b/src/main/java/org/minturtle/careersupport/common/exception/InternalServerException.java
@@ -1,0 +1,12 @@
+package org.minturtle.careersupport.common.exception;
+
+public class InternalServerException extends RuntimeException{
+
+    public InternalServerException(String message) {
+        super(message);
+    }
+
+    public InternalServerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/minturtle/careersupport/common/utils/ReactiveEncryptUtils.java
+++ b/src/main/java/org/minturtle/careersupport/common/utils/ReactiveEncryptUtils.java
@@ -1,0 +1,75 @@
+package org.minturtle.careersupport.common.utils;
+
+
+import org.minturtle.careersupport.common.exception.BadRequestException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class ReactiveEncryptUtils {
+
+    private final SecretKey secretKey;
+    private final String algorithm;
+    private final int ivLength;
+    private final int tagLength;
+
+    public ReactiveEncryptUtils(
+            @Value("${spring.encryption.key}") String encryptionKey,
+            @Value("${spring.encryption.algorithm}") String algorithm,
+            @Value("${spring.encryption.key.iv-length}") int ivLength,
+            @Value("${spring.encryption.key.tag-length}") int tagLength
+    ) {
+        this.secretKey = new SecretKeySpec(Base64.getDecoder().decode(encryptionKey), "AES");
+        this.algorithm = algorithm;
+        this.ivLength = ivLength;
+        this.tagLength = tagLength;
+    }
+
+    public Mono<String> encrypt(String data) {
+        return Mono.fromCallable(() -> {
+            byte[] iv = new byte[ivLength];
+            new SecureRandom().nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(algorithm);
+            GCMParameterSpec parameterSpec = new GCMParameterSpec(tagLength * 8, iv);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, parameterSpec);
+
+            byte[] encryptedData = cipher.doFinal(data.getBytes(StandardCharsets.UTF_8));
+            ByteBuffer byteBuffer = ByteBuffer.allocate(iv.length + encryptedData.length);
+            byteBuffer.put(iv);
+            byteBuffer.put(encryptedData);
+
+            return Base64.getEncoder().encodeToString(byteBuffer.array());
+        }).onErrorMap(e -> new RuntimeException("Encryption failed", e));
+    }
+
+    public Mono<String> decrypt(String encryptedData) {
+        return Mono.fromCallable(() -> {
+            byte[] decodedData = Base64.getDecoder().decode(encryptedData);
+
+            ByteBuffer byteBuffer = ByteBuffer.wrap(decodedData);
+            byte[] iv = new byte[ivLength];
+            byteBuffer.get(iv);
+            byte[] cipherText = new byte[byteBuffer.remaining()];
+            byteBuffer.get(cipherText);
+
+            Cipher cipher = Cipher.getInstance(algorithm);
+            GCMParameterSpec parameterSpec = new GCMParameterSpec(tagLength * 8, iv);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, parameterSpec);
+
+            byte[] decryptedData = cipher.doFinal(cipherText);
+            return new String(decryptedData, StandardCharsets.UTF_8);
+        }).onErrorMap(e -> new BadRequestException("Decryption failed", e));
+    }
+}

--- a/src/main/java/org/minturtle/careersupport/user/controller/UserController.java
+++ b/src/main/java/org/minturtle/careersupport/user/controller/UserController.java
@@ -6,9 +6,11 @@ import org.minturtle.careersupport.common.exception.BadRequestException;
 import org.minturtle.careersupport.common.exception.ConflictException;
 import org.minturtle.careersupport.common.exception.UnAuthorizedException;
 import org.minturtle.careersupport.user.dto.*;
+import org.minturtle.careersupport.user.resolvers.annotations.CurrentUser;
 import org.minturtle.careersupport.user.service.UserService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -42,5 +44,14 @@ public class UserController {
         return userService.getUserInfo(token)
                 .onErrorResume(e->{ throw new UnAuthorizedException(e.getMessage());})
                 .map(ResponseEntity::ok);
+    }
+
+    @GetMapping("/api-token")
+    public Mono<ResponseEntity<UserApiAccessTokenResponse>> getUserApiToken(
+            @CurrentUser UserInfoDto user
+    ){
+        return userService.getUserApiAccessToken(user.getId()).map(
+                token -> ResponseEntity.status(HttpStatusCode.valueOf(201)).body(token)
+        );
     }
 }

--- a/src/main/java/org/minturtle/careersupport/user/dto/UserApiAccessTokenResponse.java
+++ b/src/main/java/org/minturtle/careersupport/user/dto/UserApiAccessTokenResponse.java
@@ -1,0 +1,7 @@
+package org.minturtle.careersupport.user.dto;
+
+
+
+public record UserApiAccessTokenResponse(String token) {
+
+}

--- a/src/main/java/org/minturtle/careersupport/user/dto/UserInfoDto.java
+++ b/src/main/java/org/minturtle/careersupport/user/dto/UserInfoDto.java
@@ -4,16 +4,20 @@ package org.minturtle.careersupport.user.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.minturtle.careersupport.user.entity.User;
 
+import java.util.Objects;
+
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @Builder
 public class UserInfoDto {
 
-    private final String id;
-    private final String nickname;
-    private final String username;
+    private String id;
+    private String nickname;
+    private String username;
 
     public static UserInfoDto of(Object user){
         if (user instanceof User u) {
@@ -29,4 +33,16 @@ public class UserInfoDto {
 
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        UserInfoDto that = (UserInfoDto) object;
+        return Objects.equals(id, that.id) && Objects.equals(nickname, that.nickname) && Objects.equals(username, that.username);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, nickname, username);
+    }
 }

--- a/src/main/java/org/minturtle/careersupport/user/entity/User.java
+++ b/src/main/java/org/minturtle/careersupport/user/entity/User.java
@@ -25,4 +25,9 @@ public class User {
 
     private String password;
 
+    private String apiToken;
+
+    public void setApiToken(String apiToken) {
+        this.apiToken = apiToken;
+    }
 }

--- a/src/test/java/org/minturtle/careersupport/auth/utils/ApiTokenProviderTest.java
+++ b/src/test/java/org/minturtle/careersupport/auth/utils/ApiTokenProviderTest.java
@@ -1,0 +1,67 @@
+package org.minturtle.careersupport.auth.utils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.minturtle.careersupport.common.exception.BadRequestException;
+import org.minturtle.careersupport.common.utils.ReactiveEncryptUtils;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.*;
+
+class ApiTokenProviderTest {
+
+    private ReactiveEncryptUtils reactiveEncryptUtils =
+            new ReactiveEncryptUtils("X1XnwJ2Vrdw9wqdfX0rOdLfNJ8rwrvB9");
+    private ApiTokenProvider apiTokenProvider =
+            new ApiTokenProvider(reactiveEncryptUtils);
+
+
+    @Test
+    @DisplayName("API 토큰을 생성할 수 있다.")
+    void testGenerateShouldReturnNonEmptyToken() {
+        String testUserId = "abc123";
+        Mono<String> tokenMono = apiTokenProvider.generate(testUserId);
+
+        StepVerifier.create(tokenMono)
+                .assertNext(token -> {
+                    assertThat(token).isNotBlank();
+                    assertThat(token).startsWith("cs_");
+                    assertThat(token.length()).isGreaterThan(3);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("생성한 토큰을 해독해서 userId를 반환받을 수 있다.")
+    void testDecryptApiTokenShouldReturnOriginalUserId() {
+        String testUserId = "abc123";
+        Mono<String> tokenMono = apiTokenProvider.generate(testUserId);
+
+        StepVerifier.create(tokenMono)
+                .assertNext(token -> {
+                    Mono<String> decryptedUserIdMono = apiTokenProvider.decryptApiToken(token);
+
+                    StepVerifier.create(decryptedUserIdMono)
+                            .expectNext(testUserId)
+                            .verifyComplete();
+                })
+                .verifyComplete();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "invalid", "cs_invalid"})
+    @DisplayName("API 토큰이 잘못된 경우 BadRequestException을 throw한다.")
+    public void testDecryptThrowsBadRequestException(String invalidToken) throws Exception{
+        Mono<String> decryptedUserIdMono = apiTokenProvider.decryptApiToken(invalidToken);
+
+        StepVerifier.create(decryptedUserIdMono)
+                .expectError(BadRequestException.class)
+                .verify();
+
+    }
+
+}

--- a/src/test/java/org/minturtle/careersupport/codereview/controller/CodeReviewControllerTest.java
+++ b/src/test/java/org/minturtle/careersupport/codereview/controller/CodeReviewControllerTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.minturtle.careersupport.codereview.dto.CodeReviewRequest;
 import org.minturtle.careersupport.testutils.IntegrationTest;
+import org.minturtle.careersupport.user.dto.UserInfoDto;
+import org.minturtle.careersupport.user.entity.User;
 import org.springframework.http.MediaType;
 import reactor.core.publisher.Mono;
 
@@ -24,6 +26,9 @@ class CodeReviewControllerTest extends IntegrationTest {
     @DisplayName("Code Review에 필요한 Request Body를 코드리뷰를 요청할 수 있다.")
     void testCodeReviewApiCall() throws Exception{
         // given
+        User user = createUser();
+        String apiToken = apiTokenProvider.generate(UserInfoDto.of(user)).block();
+
         CodeReviewRequest codeReviewRequestBody = CodeReviewRequest.builder()
                 .repositoryName("minturtle/careersupport")
                 .prNumber(1L)
@@ -39,6 +44,7 @@ class CodeReviewControllerTest extends IntegrationTest {
         // when & then
         webTestClient.post()
                 .uri("/api/code-review")
+                .header("X-API-TOKEN", apiToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(codeReviewRequestBody)
                 .exchange()

--- a/src/test/java/org/minturtle/careersupport/common/controller/CommonControllerTest.java
+++ b/src/test/java/org/minturtle/careersupport/common/controller/CommonControllerTest.java
@@ -1,7 +1,15 @@
 package org.minturtle.careersupport.common.controller;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.minturtle.careersupport.auth.utils.ApiTokenProvider;
 import org.minturtle.careersupport.testutils.IntegrationTest;
+import org.minturtle.careersupport.user.dto.UserInfoDto;
+import org.minturtle.careersupport.user.entity.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -9,10 +17,36 @@ import static org.assertj.core.api.Assertions.*;
 
 
 class CommonControllerTest extends IntegrationTest {
+
+    @Autowired
+    private ApiTokenProvider apiTokenProvider;
+
     @Test
     public void testHealthCheck() {
         webTestClient.get().uri("/api/health-check")
                 .exchange()
                 .expectStatus().isOk();
+    }
+
+    @Test
+    @DisplayName("API 토큰이 필요한 api에서 currentUser의 정보를 잘 가져올 수 있다.")
+    public void testGetUserInfoFromApiToken() throws Exception{
+        //given
+        User user = createUser();
+
+        String apiToken = this.apiTokenProvider.generate(UserInfoDto.of(user)).block();
+
+        //when
+        Flux<String> responseBody = webTestClient.get().uri("/api/api-check")
+                .header("X-API-TOKEN", apiToken)
+                .exchange()
+                .expectStatus().isOk()
+                .returnResult(String.class)
+                .getResponseBody();
+
+        StepVerifier.create(responseBody)
+                .assertNext(s->assertThat(s).contains(user.getNickname()))
+                .verifyComplete();
+
     }
 }

--- a/src/test/java/org/minturtle/careersupport/common/utils/ReactiveEncryptUtilsTest.java
+++ b/src/test/java/org/minturtle/careersupport/common/utils/ReactiveEncryptUtilsTest.java
@@ -1,0 +1,55 @@
+package org.minturtle.careersupport.common.utils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.minturtle.careersupport.common.exception.BadRequestException;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReactiveEncryptUtilsTest {
+
+    private final ReactiveEncryptUtils encryptUtils = new ReactiveEncryptUtils(
+            "X1XnwJ2Vrdw9wqdfX0rOdLfNJ8rwrvB9",
+            "AES/GCM/NoPadding",
+            12,
+            16
+    );
+
+    private final String testData = "Hello, World!";
+
+    @Test
+    @DisplayName("데이터를 Encrypt하고, Decrypt해서 데이터를 복구할 수 있다.")
+    void encryptAndDecrypt() {
+        Mono<String> encryptedData = encryptUtils.encrypt(testData);
+        Mono<String> decryptedData = encryptedData.flatMap(encryptUtils::decrypt);
+
+        StepVerifier.create(decryptedData)
+                .expectNext(testData)
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("같은 문자열을 암호화하더라도, 다른 암호화 결과를 받을 수 있다.")
+    void encryptProducesDifferentOutputForSameInput() {
+        Mono<String> encrypted1 = encryptUtils.encrypt(testData);
+        Mono<String> encrypted2 = encryptUtils.encrypt(testData);
+
+        StepVerifier.create(Mono.zip(encrypted1, encrypted2))
+                .assertNext(tuple -> assertThat(tuple.getT1()).isNotEqualTo(tuple.getT2()))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("잘못된 데이터를 decrypt할 시 BadRequestException을 throw한다.")
+    void decryptFailsForInvalidData() {
+        Mono<String> decryptedData = encryptUtils.decrypt("InvalidEncryptedData");
+
+        StepVerifier.create(decryptedData)
+                .expectError(BadRequestException.class)
+                .verify();
+    }
+
+
+}

--- a/src/test/java/org/minturtle/careersupport/common/utils/ReactiveEncryptUtilsTest.java
+++ b/src/test/java/org/minturtle/careersupport/common/utils/ReactiveEncryptUtilsTest.java
@@ -11,10 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ReactiveEncryptUtilsTest {
 
     private final ReactiveEncryptUtils encryptUtils = new ReactiveEncryptUtils(
-            "X1XnwJ2Vrdw9wqdfX0rOdLfNJ8rwrvB9",
-            "AES/GCM/NoPadding",
-            12,
-            16
+            "X1XnwJ2Vrdw9wqdfX0rOdLfNJ8rwrvB9"
     );
 
     private final String testData = "Hello, World!";

--- a/src/test/java/org/minturtle/careersupport/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/org/minturtle/careersupport/interview/controller/InterviewControllerTest.java
@@ -56,15 +56,11 @@ class InterviewControllerTest extends IntegrationTest {
     @DisplayName("로그인이 완료된 사용자는 자신이 지금까지 했던 면접 주제를 조회할 수 있다.")
     public void testUserGetInterviewTemplate() throws Exception{
         //given
-        String userId = "123";
-        String nickname = "nickname";
-        String username = "username";
-        String password = "password";
 
-        User user = new User(userId, nickname, username, password);
+        User user = createUser();
         List<InterviewTemplate> givenInterviewTemplates = List.of(
-                InterviewTemplate.builder().userId(userId).theme("theme1").build(),
-                InterviewTemplate.builder().userId(userId).theme("theme2").build()
+                InterviewTemplate.builder().userId(user.getId()).theme("theme1").build(),
+                InterviewTemplate.builder().userId(user.getId()).theme("theme2").build()
         );
 
         userRepository.save(user).block();
@@ -94,15 +90,11 @@ class InterviewControllerTest extends IntegrationTest {
     @DisplayName("로그인이 완료된 사용자는 특정 면접 주제에 대한 첫번째 페이지의 메시지 리스트를 조회할 수 있다.")
     public void testUserGetInterviewMessage() throws Exception{
         //given
-        String userId = "123";
-        String nickname = "nickname";
-        String username = "username";
-        String password = "password";
 
         String templateId = "456";
 
-        User user = new User(userId, nickname, username, password);
-        InterviewTemplate interviewTemplate = InterviewTemplate.builder().id(templateId).userId(userId).theme("theme1").build();
+        User user = createUser();
+        InterviewTemplate interviewTemplate = InterviewTemplate.builder().id(templateId).userId(user.getId()).theme("theme1").build();
 
         List<InterviewMessage> interviewMessages = List.of(
                 InterviewMessage.builder()
@@ -162,15 +154,11 @@ class InterviewControllerTest extends IntegrationTest {
     @DisplayName("로그인이 완료된 사용자는 특정 면접 주제에 대한 두번째 이상 페이지의 메시지 리스트를 조회할 수 있다.")
     public void testUserGetInterviewMessageNextCursor() throws Exception{
         //given
-        String userId = "123";
-        String nickname = "nickname";
-        String username = "username";
-        String password = "password";
 
         String templateId = "456";
 
-        User user = new User(userId, nickname, username, password);
-        InterviewTemplate interviewTemplate = InterviewTemplate.builder().id(templateId).userId(userId).theme("theme1").build();
+        User user = createUser();
+        InterviewTemplate interviewTemplate = InterviewTemplate.builder().id(templateId).userId(user.getId()).theme("theme1").build();
 
         List<InterviewMessage> interviewMessages = List.of(
                 InterviewMessage.builder()
@@ -232,12 +220,8 @@ class InterviewControllerTest extends IntegrationTest {
     public void testUserCreateNewInterviewTemplate() throws Exception{
         //given
         String theme = "Java Programming";
-        String userId = "123";
-        String nickname = "nickname";
-        String username = "username";
-        String password = "password";
 
-        User user = new User(userId, nickname, username, password);
+        User user = createUser();
 
         userRepository.save(user).block();
 
@@ -270,14 +254,10 @@ class InterviewControllerTest extends IntegrationTest {
         //given
         String theme = "Java Programming";
         String templateId = "template001";
-        String userId = "123";
-        String nickname = "nickname";
-        String username = "username";
-        String password = "password";
         Flux<String> mockQuestions = Flux.just("질문", ":", "당신의 이름은?");
 
-        User user = new User(userId, nickname, username, password);
-        InterviewTemplate interviewTemplate = InterviewTemplate.builder().id(templateId).userId(userId).theme(theme).build();
+        User user = createUser();
+        InterviewTemplate interviewTemplate = InterviewTemplate.builder().id(templateId).userId(user.getId()).theme(theme).build();
 
         given(chatService.generate(anyString(), eq(theme)))
                 .willReturn(mockQuestions);
@@ -320,15 +300,11 @@ class InterviewControllerTest extends IntegrationTest {
         //given
         String theme = "Java Programming";
         String templateId = "template001";
-        String userId = "123";
-        String nickname = "nickname";
-        String username = "username";
-        String password = "password";
         Flux<String> mockFollowQuestions = Flux.just("다음 질문", ":", "당신의 나이는?");
         String prevQuestionContent = "질문 : 당신의 이름은?";
 
-        User user = new User(userId, nickname, username, password);
-        InterviewTemplate interviewTemplate = InterviewTemplate.builder().id(templateId).userId(userId).theme(theme).build();
+        User user = createUser();
+        InterviewTemplate interviewTemplate = InterviewTemplate.builder().id(templateId).userId(user.getId()).theme(theme).build();
 
         InterviewMessage prevQuestion = InterviewMessage.builder()
                 .id("message1")

--- a/src/test/java/org/minturtle/careersupport/testutils/IntegrationTest.java
+++ b/src/test/java/org/minturtle/careersupport/testutils/IntegrationTest.java
@@ -20,6 +20,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
@@ -37,6 +38,9 @@ public abstract class IntegrationTest {
     protected WebTestClient webTestClient;
 
     @Autowired
+    protected PasswordEncoder passwordEncoder;
+
+    @Autowired
     protected JwtTokenProvider jwtTokenProvider;
 
     @MockBean
@@ -45,6 +49,18 @@ public abstract class IntegrationTest {
     // TODO : 추후 실제 빈으로 변경
     @MockBean
     protected CodeReviewService codeReviewService;
+
+    protected static final String DEFAULT_USER_RAW_PASSWORD = "password";
+    protected User createUser(){
+        return createUser("username", DEFAULT_USER_RAW_PASSWORD);
+    }
+
+    protected User createUser(String username, String password){
+        String nickname = "nickname";
+
+        return new User("123", nickname, username, passwordEncoder.encode(password));
+
+    }
 
     protected String createJwtToken(User user){
         return jwtTokenProvider.sign(UserInfoDto.of(user), new Date()).block();

--- a/src/test/java/org/minturtle/careersupport/testutils/IntegrationTest.java
+++ b/src/test/java/org/minturtle/careersupport/testutils/IntegrationTest.java
@@ -58,7 +58,7 @@ public abstract class IntegrationTest {
     protected User createUser(String username, String password){
         String nickname = "nickname";
 
-        return new User("123", nickname, username, passwordEncoder.encode(password));
+        return new User("123", nickname, username, passwordEncoder.encode(password), null);
 
     }
 

--- a/src/test/java/org/minturtle/careersupport/testutils/IntegrationTest.java
+++ b/src/test/java/org/minturtle/careersupport/testutils/IntegrationTest.java
@@ -6,6 +6,7 @@ import de.bwaldvogel.mongo.MongoServer;
 import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.minturtle.careersupport.auth.utils.ApiTokenProvider;
 import org.minturtle.careersupport.auth.utils.JwtTokenProvider;
 import org.minturtle.careersupport.codereview.service.CodeReviewService;
 import org.minturtle.careersupport.common.service.ChatService;
@@ -42,6 +43,9 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    protected ApiTokenProvider apiTokenProvider;
 
     @MockBean
     protected ChatService chatService;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,6 +7,8 @@ spring:
       messages:
         interview-system-message: message1
         follow-system-message: message2
+  encryption:
+    key: gwIYgK2kSV3RM7FT3ORbNUm3Mp0lWalD
 
 cors:
   origins: http://localhost:3000


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #35 

## 📝작업 내용

- 암호화 알고리즘을 사용한 양방향 암호화 Util 클래스를 추가하였습니다.
- 반영구적인 API Token을 생성하는 Util클래스를 추가하였습니다.
- API Token을 발급 받는 API를 추가하였습니다.
    -  API Token은 생성되었을 때 한번만 조회가 가능하며, 분실시 재발급 받도록 설계하였습니다.
- API Token을 해독하여 SecurityContextHolder에 저장하는 로직을 추가하였습니다.


